### PR TITLE
Add Rust port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 genprime-*
 genprime.*.py
 *.rbc
+Cargo.lock
+target/
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "genprime-rust"
 version = "0.1.0"
-authors = [ "Eddie Ringle <eddie@ringle.io" ]
+authors = [ "Eddie Ringle <eddie@ringle.io>" ]
 license = "BSD-3-Clause"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ path = "genprime.rs"
 
 [dependencies]
 
+num = "*"
 time = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+
+name = "genprime-rust"
+version = "0.1.0"
+authors = [ "Eddie Ringle <eddie@ringle.io" ]
+license = "BSD-3-Clause"
+
+[[bin]]
+
+name = "genprime-rust"
+path = "genprime.rs"
+
+[dependencies]
+
+time = "*"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 ARGS=25000 100000
 
-all: genprime-java genprime-c genprime-f90 genprime-pyx genprime-py27 genprime-py30 genprime-objc genprime-cpp genprime-cs genprime-c-llvm genprime-c-icc genprime-c-clang genprime-swift
+all: genprime-java genprime-c genprime-f90 genprime-pyx genprime-py27 genprime-py30 genprime-objc genprime-cpp genprime-cs genprime-c-llvm genprime-c-icc genprime-c-clang genprime-swift genprime-rust
 
 clean:
-	rm -f genprime.*.py *.pyc *.class genprime-* *.s *.bc *.ll *.rbc
+	rm -rf genprime.*.py *.pyc *.class genprime-* *.s *.bc *.ll *.rbc target
 
 version:
 	@echo
@@ -46,6 +46,9 @@ version:
 	-rbx -v
 	@echo
 	-swift -v
+	@echo
+	-rustc --version
+	-cargo --version
 	@echo
 
 run: all
@@ -114,6 +117,9 @@ run: all
 	@echo
 	@echo "genprime (Swift)"
 	@-./genprime-swift $(ARGS)
+	@echo
+	@echo "genprime (Rust)"
+	@-./target/release/genprime-rust $(ARGS)
 
 genprime-java: genprime.class
 
@@ -184,3 +190,6 @@ genprime.30.pyc: genprime.py
 genprime-swift: genprime.swift
 	-swift -O3 -sdk $(shell xcrun --show-sdk-path --sdk macosx) -o genprime-swift genprime.swift
 	@echo
+
+genprime-rust: genprime.rs
+	-cargo build --release

--- a/genprime.rs
+++ b/genprime.rs
@@ -1,7 +1,6 @@
 extern crate time;
 
 use std::os;
-use std::str::FromStr;
 use std::num::Float;
 use std::iter;
 
@@ -58,13 +57,13 @@ fn main() {
     let mut   end: f64;
 
     start = if args.len() > 1 {
-        FromStr::from_str(&*os::args()[1]).unwrap()
+        args[1].parse().unwrap()
     } else {
         0
     };
 
     stop = if args.len() > 2 {
-        FromStr::from_str(&*os::args()[2]).unwrap()
+        args[2].parse().unwrap()
     } else {
         0
     };

--- a/genprime.rs
+++ b/genprime.rs
@@ -1,0 +1,78 @@
+extern crate time;
+
+use std::os;
+use std::str::FromStr;
+use std::num::Float;
+use std::iter;
+
+fn isprime(x: u64) -> bool {
+    let lim: u64;
+
+    if x < 2 {
+        return false;
+    }
+    if x == 2 {
+        return true;
+    }
+    if x % 2 == 0 {
+        return false;
+    }
+    if x < 9 {
+        return true;
+    }
+    if (x + 1) % 6 != 0 {
+        if (x - 1) % 6 != 0 {
+            return false;
+        }
+    }
+    lim = Float::sqrt(((x as f64) + 1.0f64)) as u64;
+    for y in iter::range_step_inclusive(3, lim, 2) {
+        if x % y == 0 {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+fn genprime(max: u64) -> u64 {
+    let mut   count: u64 = 0;
+    let mut current: u64 = 1;
+
+    while count < max {
+        if isprime(current) {
+            count += 1;
+        }
+        current += 1;
+    }
+
+    return current - 1;
+}
+
+fn main() {
+    let  args: Vec<String> = os::args();
+    let start: u64;
+    let  stop: u64;
+    let mut  last: u64;
+    let mut begin: f64;
+    let mut   end: f64;
+
+    start = if args.len() > 1 {
+        FromStr::from_str(&*os::args()[1]).unwrap()
+    } else {
+        0
+    };
+
+    stop = if args.len() > 2 {
+        FromStr::from_str(&*os::args()[2]).unwrap()
+    } else {
+        0
+    };
+
+    for x in iter::range_step_inclusive(start, stop, start) {
+        begin = time::precise_time_s();
+        last = genprime(x);
+        end = time::precise_time_s();
+        println!("Found {:8} primes in {:10.5} seconds (last was {:10})", x, end - begin, last);
+    }
+}

--- a/genprime.rs
+++ b/genprime.rs
@@ -1,8 +1,9 @@
+extern crate num;
 extern crate time;
 
-use std::os;
-use std::num::Float;
-use std::iter;
+use std::env;
+
+use num::iter;
 
 fn isprime(x: u64) -> bool {
     let lim: u64;
@@ -24,7 +25,7 @@ fn isprime(x: u64) -> bool {
             return false;
         }
     }
-    lim = Float::sqrt(((x as f64) + 1.0f64)) as u64;
+    lim = ((x as f64) + 1.0f64).sqrt() as u64;
     for y in iter::range_step_inclusive(3, lim, 2) {
         if x % y == 0 {
             return false;
@@ -49,7 +50,7 @@ fn genprime(max: u64) -> u64 {
 }
 
 fn main() {
-    let  args: Vec<String> = os::args();
+    let  args: Vec<String> = env::args().collect();
     let start: u64;
     let  stop: u64;
     let mut  last: u64;


### PR DESCRIPTION
Started learning Rust since 1.0 is apparently around the corner. Thought I would implement genprime as an exercise.

Now, it seems they moved the precise time functions out of the standard library and into a separate package, so I had to use Cargo to build instead of sticking to `rustc`. Cargo also doesn't appear to let you change the output path of the built binary, so it's stuck in a target directory.
