### PR TITLE
Crystal: Force 64-bit maths

### DIFF
--- a/genprime.cr
+++ b/genprime.cr
@@ -1,4 +1,4 @@
-def isprime(x)
+def isprime(x : UInt64)
     if x < 2
         return 0
     end
@@ -16,7 +16,7 @@ def isprime(x)
             return 0
         end
     end
-    lim = Math.sqrt(x).to_i + 1
+    lim = (Math.sqrt(x) + 1.0).to_u64
     y = 3
     while y <= lim
         if x % y == 0
@@ -27,9 +27,9 @@ def isprime(x)
     return 1
 end
 
-def genprime(max)
-    count = 0
-    current = 1
+def genprime(max : UInt64)
+    count = 0_u64
+    current = 1_u64
     while count < max
         if isprime(current) != 0
             count += 1
@@ -39,8 +39,8 @@ def genprime(max)
     return current - 1
 end
 
-start = ARGV[0].to_i
-stop = ARGV[1].to_i + 1
+start = ARGV[0].to_u64
+stop = ARGV[1].to_u64 + 1
 i = start
 if start == 0
     Process.exit

--- a/genprime.cr
+++ b/genprime.cr
@@ -1,28 +1,28 @@
 def isprime(x : UInt64)
-    if x < 2
+    if x < 2_u64
         return 0
     end
-    if x == 2
+    if x == 2_u64
         return 1
     end
-    if x % 2 == 0
+    if x % 2_u64 == 0_u64
         return 0
     end
-    if x < 9
+    if x < 9_u64
         return 1
     end
-    if (x + 1) % 6 != 0
-        if (x - 1) % 6 != 0
+    if (x + 1_u64) % 6_u64 != 0_u64
+        if (x - 1_u64) % 6_u64 != 0_u64
             return 0
         end
     end
     lim = (Math.sqrt(x) + 1.0).to_u64
-    y = 3
+    y = 3_u64
     while y <= lim
-        if x % y == 0
+        if x % y == 0_u64
             return 0
         end
-        y += 2
+        y += 2_u64
     end
     return 1
 end
@@ -32,15 +32,15 @@ def genprime(max : UInt64)
     current = 1_u64
     while count < max
         if isprime(current) != 0
-            count += 1
+            count += 1_u64
         end
-        current += 1
+        current += 1_u64
     end
-    return current - 1
+    return current - 1_u64
 end
 
 start = ARGV[0].to_u64
-stop = ARGV[1].to_u64 + 1
+stop = ARGV[1].to_u64 + 1_u64
 i = start
 if start == 0
     Process.exit


### PR DESCRIPTION
As you pointed out in the last PR, the Crystal version was using 32-bit integers. This patch fixes that.

New benchmark against Clang:

```
ganglion:genprime eddie$ ./genprime-crystal 250000 1000000
Found   250000 primes in    1.65555 seconds (last was    3497861)
Found   500000 primes in    4.67614 seconds (last was    7368787)
Found   750000 primes in    8.79405 seconds (last was   11381621)
Found  1000000 primes in   13.79081 seconds (last was   15485863)

ganglion:genprime eddie$ ./genprime-c-clang 250000 1000000
Found   250000 primes in    1.75610 seconds (last was    3497861)
Found   500000 primes in    5.02919 seconds (last was    7368787)
Found   750000 primes in    9.30910 seconds (last was   11381621)
Found  1000000 primes in   15.12655 seconds (last was   15485863)
```
