### PR TITLE
Add Pony port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARGS=25000 100000
 
-all: genprime-java genprime-c genprime-f90 genprime-pyx genprime-py27 genprime-py30 genprime-objc genprime-cpp genprime-cs genprime-c-llvm genprime-c-icc genprime-c-clang genprime-swift genprime-crystal
+all: genprime-java genprime-c genprime-f90 genprime-pyx genprime-py27 genprime-py30 genprime-objc genprime-cpp genprime-cs genprime-c-llvm genprime-c-icc genprime-c-clang genprime-swift genprime-crystal genprime-pony
 
 clean:
 	rm -f genprime.*.py *.pyc *.class genprime-* *.s *.bc *.ll *.rbc
@@ -48,6 +48,8 @@ version:
 	-swift -v
 	@echo
 	-crystal --version
+	@echo
+	-ponyc --version
 	@echo
 
 run: all
@@ -119,6 +121,9 @@ run: all
 	@echo
 	@echo "genprime (Crystal)"
 	@-./genprime-crystal $(ARGS)
+	@echo
+	@echo "genprime (Pony)"
+	@-./genprime-pony1 $(ARGS)
 
 genprime-java: genprime.class
 
@@ -192,4 +197,10 @@ genprime-swift: genprime.swift
 
 genprime-crystal: genprime.cr
 	-crystal build --release -o genprime-crystal genprime.cr
+	@echo
+
+genprime-pony: genprime-pony1
+
+genprime-pony1: genprime-pony/genprime.pony
+	-ponyc genprime-pony
 	@echo

--- a/genprime-pony/genprime.pony
+++ b/genprime-pony/genprime.pony
@@ -1,0 +1,65 @@
+use "collections"
+use "time"
+
+actor Main
+  var _env: Env
+
+  fun isPrime(x: U64): Bool =>
+    var lim: U64
+    if (x < 2) then
+      return false
+    end
+    if (x == 2) then
+      return true
+    end
+    if ((x % 2) == 0) then
+      return false
+    end
+    if (x < 9) then
+      return true
+    end
+    if (((x + 1) % 6) != 0) then
+      if (((x - 1) % 6) != 0) then
+        return false
+      end
+    end
+    lim = (x.f64().sqrt() + 1.0).u64()
+    for y in Range[U64](3, lim, 2) do
+      if ((x % y) == 0) then
+        return false
+      end
+    end
+    true
+
+    fun genprime(max: U64): U64 =>
+      var count: U64 = 0
+      var current: U64 = 1
+      while count < max do
+        if isPrime(current) then
+          count = count + 1
+        end
+        current = current + 1
+      end
+      current - 1
+
+  new create(env: Env) =>
+    _env = env
+
+    let start: U32 = try env.args(1).u32() else 25000 end
+    let stop: U32 = try env.args(2).u32() else 100000 end
+
+    var startTime: (I64, I64)
+    var endTime: (I64, I64)
+
+    for i in Range[U32](start, stop + 1, start) do
+      startTime = Time.now()
+      let last = genprime(i.u64())
+      endTime = Time.now()
+      let duration = (endTime._1 - startTime._1, endTime._2 - startTime._2)
+      let seconds: F64 = duration._1.f64() + (duration._2.f64() / 1000000000.0)
+      env.out.print(
+        "Found " + i.string() + " primes in "
+          + seconds.string() + " seconds "
+          + " (last was " + last.string() + ")"
+      )
+    end


### PR DESCRIPTION
Another new language!

Benchmark against Clang:

```
ganglion:genprime eddie$ clang-3.6 --version
clang version 3.6.0 (tags/RELEASE_360/final)
Target: x86_64-apple-darwin14.3.0
Thread model: posix

ganglion:genprime eddie$ ./genprime-c-clang 250000 1000000
Found   250000 primes in    1.86309 seconds (last was    3497861)
Found   500000 primes in    5.59027 seconds (last was    7368787)
Found   750000 primes in    9.71649 seconds (last was   11381621)
Found  1000000 primes in   15.33942 seconds (last was   15485863)

ganglion:genprime eddie$ ls -al genprime-c-clang
-rwxr-xr-x  1 eddie  staff  8680 May  4 11:29 genprime-c-clang
```

---

```
ganglion:genprime eddie$ ponyc --version
0.1.2-1-g08ff6b2

ganglion:genprime eddie$ ./genprime-pony1 250000 1000000
Found   250000 primes in    1.79646 seconds (last was    3497861)
Found   500000 primes in    5.20687 seconds (last was    7368787)
Found   750000 primes in    9.49915 seconds (last was   11381621)
Found  1000000 primes in   14.75800 seconds (last was   15485863)

ganglion:genprime eddie$ ls -al genprime-pony1
-rwxr-xr-x  1 eddie  staff  93112 May  4 13:22 genprime-pony1
```

I formatted the output here myself since I couldn't find any printf equivalent in Pony's stdlib yet, though I suppose I could've called into C for that. Also, while I'm pretty sure the nanosecond -> fraction conversion is correct, it's possible I misinterpreted something in the docs (that is, the stdlib source code, since there isn't much documentation for Pony yet).
